### PR TITLE
11: Update widget components to integrate Jotai for state management …

### DIFF
--- a/apps/widget/components/providers.tsx
+++ b/apps/widget/components/providers.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
 import { ConvexProvider, ConvexReactClient } from "convex/react"
+import { Provider } from "jotai"
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
 
@@ -16,7 +17,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
         disableTransitionOnChange
         enableColorScheme
       >
-        {children}
+        <Provider>
+          {children}
+        </Provider>
       </NextThemesProvider>
     </ConvexProvider>
   )

--- a/apps/widget/modules/widget/atoms/widget-atoms.ts
+++ b/apps/widget/modules/widget/atoms/widget-atoms.ts
@@ -1,0 +1,4 @@
+import { atom } from "jotai";
+import { WidgetScreen } from "../types";
+
+export const screenAtom = atom<WidgetScreen>("auth");

--- a/apps/widget/modules/widget/constants.ts
+++ b/apps/widget/modules/widget/constants.ts
@@ -1,0 +1,12 @@
+export const WIDGET_SCREENS = [
+    "error",
+    "loading",
+    "selection",
+    "voice",
+    "auth",
+    "inbox",
+    "chat",
+    "contact"
+] as const;
+
+export const CONTACT_SESSION_KEY = "echo_contact_session";

--- a/apps/widget/modules/widget/types.ts
+++ b/apps/widget/modules/widget/types.ts
@@ -1,0 +1,3 @@
+import { WIDGET_SCREENS } from "./constants";
+
+export type WidgetScreen = (typeof WIDGET_SCREENS)[number];

--- a/apps/widget/modules/widget/ui/screens/widgetAuthScreen.tsx
+++ b/apps/widget/modules/widget/ui/screens/widgetAuthScreen.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import WidgetHeader from '../components/widgetHeader'
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@workspace/ui/components/form'
+import { 
+    Form, 
+    FormControl, 
+    FormField, 
+    FormItem, 
+    FormLabel, 
+    FormMessage 
+} from '@workspace/ui/components/form'
 import { Button } from '@workspace/ui/components/button'
 import { Input } from '@workspace/ui/components/input'
 import { useForm } from 'react-hook-form'

--- a/apps/widget/modules/widget/ui/views/widgetView.tsx
+++ b/apps/widget/modules/widget/ui/views/widgetView.tsx
@@ -1,16 +1,29 @@
 "use client"
 
 interface Props {
-    organizationId: string;
+  organizationId: string;
 }
 
 import React from 'react'
+import { useAtomValue } from 'jotai';
 import WidgetAuthScreen from '../screens/widgetAuthScreen';
+import { screenAtom } from '@/modules/widget/atoms/widget-atoms';
 
 const WidgetView = ({ organizationId }: Props) => {
+  const screen = useAtomValue(screenAtom);
+  const screenComponents = {
+    error: <p>TODO: Error Screen</p>,
+    loading: <p>TODO: Loading Screen</p>,
+    selection: <p>TODO: Selection Screen</p>,
+    voice: <p>TODO: Voice Screen</p>,
+    auth: <WidgetAuthScreen />,
+    inbox: <p>TODO: Inbox Screen</p>,
+    chat: <p>TODO: Chat Screen</p>,
+    contact: <p>TODO: Contact Screen</p>,
+  }
   return (
     <main className='min-h-screen min-w-screen flex h-full w-full flex-col overflow-hidden rounded-xl border bg-muted'>
-        <WidgetAuthScreen />
+        {screenComponents[screen]}
         {/* <WidgetFooter /> */}
     </main>
   )

--- a/apps/widget/package.json
+++ b/apps/widget/package.json
@@ -18,6 +18,7 @@
     "@workspace/math": "workspace:*",
     "@workspace/ui": "workspace:*",
     "convex": "^1.25.4",
+    "jotai": "^2.13.1",
     "lucide-react": "^0.475.0",
     "next": "^15.4.5",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       convex:
         specifier: ^1.25.4
         version: 1.25.4(@clerk/clerk-react@5.40.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      jotai:
+        specifier: ^2.13.1
+        version: 2.13.1(@babel/core@7.28.0)(@babel/template@7.27.2)(@types/react@19.1.9)(react@19.1.1)
       lucide-react:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.1)
@@ -3469,6 +3472,24 @@ packages:
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
+
+  jotai@2.13.1:
+    resolution: {integrity: sha512-cRsw6kFeGC9Z/D3egVKrTXRweycZ4z/k7i2MrfCzPYsL9SIWcPXTyqv258/+Ay8VUEcihNiE/coBLE6Kic6b8A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -8154,6 +8175,13 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.5.1: {}
+
+  jotai@2.13.1(@babel/core@7.28.0)(@babel/template@7.27.2)(@types/react@19.1.9)(react@19.1.1):
+    optionalDependencies:
+      '@babel/core': 7.28.0
+      '@babel/template': 7.27.2
+      '@types/react': 19.1.9
+      react: 19.1.1
 
   js-cookie@3.0.5: {}
 


### PR DESCRIPTION
…and add new constants and types

- Added Jotai as a dependency and integrated it into the Providers component for state management.
- Created constants for widget screens and defined types for better type safety.
- Introduced screenAtom to manage the current screen state in the WidgetView component.
- Updated WidgetView to render different screens based on the current state.
- Modified package.json and pnpm-lock.yaml to include the new jotai dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The widget now dynamically renders different screens based on app state, laying groundwork for flows like auth, chat, inbox, voice, contact, loading, error, and selection.
  - Improved reliability for contact session handling with a consistent session key.
- Chores
  - Added a lightweight state management library to support shared state across the widget.
- Style
  - Minor import formatting cleanups with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->